### PR TITLE
♻️ [REFACTOR] #111 API 요청이 env 파일 사용하게끔 리팩토링

### DIFF
--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -1,0 +1,4 @@
+export const ENV = {
+  TEAM_ID: process.env.NEXT_PUBLIC_TEAM_ID,
+  API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
+};

--- a/src/services/HttpClient.ts
+++ b/src/services/HttpClient.ts
@@ -1,18 +1,18 @@
-// src/services/HttpClient.ts
+import { ENV } from '@/constants/env';
+
 export default class HttpClient {
   private static instance: HttpClient;
-  private baseUrl: string;
+  private static DEFAULT_BASE_URL = ENV.API_BASE_URL;
+  protected readonly baseUrl: string;
 
   protected constructor(baseUrl: string) {
-    this.baseUrl = baseUrl;
+    this.baseUrl = HttpClient.DEFAULT_BASE_URL || baseUrl;
   }
 
   // baseUrl을 적합한 url로 변경하여 설정.
-  public static getInstance(
-    baseUrl: string = 'https://fe-adv-project-together-dallaem.vercel.app',
-  ) {
+  public static getInstance(baseUrl?: string) {
     if (!HttpClient.instance) {
-      HttpClient.instance = new HttpClient(baseUrl);
+      HttpClient.instance = new HttpClient(baseUrl || HttpClient.DEFAULT_BASE_URL!);
     }
     return HttpClient.instance;
   }
@@ -28,7 +28,7 @@ export default class HttpClient {
             ...(options.headers || {}),
           };
 
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await fetch(`${this.baseUrl}/${ENV.TEAM_ID}${path}`, {
       ...options,
       headers,
     });

--- a/src/services/PolymorphicHttpClient.ts
+++ b/src/services/PolymorphicHttpClient.ts
@@ -1,5 +1,4 @@
-// src/services/PolymorphicHttpClient.ts
-
+import { ENV } from '@/constants/env';
 import HttpClient from './HttpClient';
 
 export default class PolymorphicHttpClient extends HttpClient {
@@ -9,11 +8,9 @@ export default class PolymorphicHttpClient extends HttpClient {
     super(baseUrl);
   }
 
-  public static getInstance(
-    baseUrl: string = 'https://fe-adv-project-together-dallaem.vercel.app',
-  ) {
+  public static getInstance(baseUrl?: string) {
     if (!PolymorphicHttpClient.pInstance) {
-      PolymorphicHttpClient.pInstance = new PolymorphicHttpClient(baseUrl);
+      PolymorphicHttpClient.pInstance = new PolymorphicHttpClient(baseUrl ?? ENV.API_BASE_URL!);
     }
     return PolymorphicHttpClient.pInstance;
   }
@@ -22,6 +19,7 @@ export default class PolymorphicHttpClient extends HttpClient {
     if (typeof window === 'undefined') {
       options.credentials = 'include';
     }
-    return super.request<T>(path, options);
+    const res = await fetch(`${this.baseUrl}/${ENV.TEAM_ID}${path}`, options);
+    return res.json() as Promise<T>;
   }
 }

--- a/src/services/Service.ts
+++ b/src/services/Service.ts
@@ -1,14 +1,3 @@
-// src/services/Service.ts
-// 이 파일은 프로젝트에 이미 존재하는 HttpClient / PolymorphicHttpClient 싱글턴 인스턴스를
-// 도메인 서비스에서 쉽게 사용하도록 추상 클래스로 감싼 것입니다.
-//
-// 기존 코드 구조와 호환되도록 다음 경로로 import 합니다:
-// - HttpClient: @/services/HttpClient
-// - PolymorphicHttpClient: @/services/PolymorphicHttpClient
-//
-// 파일을 생성한 뒤에 VSCode에서 TypeScript 서버를 재시작(TS: Restart TS Server) 하세요.
-
-// src/services/Service.ts
 import HttpClient from './HttpClient';
 import PolymorphicHttpClient from './PolymorphicHttpClient';
 

--- a/src/services/auths/AnonAuthService.ts
+++ b/src/services/auths/AnonAuthService.ts
@@ -1,4 +1,3 @@
-// src/services/auths/AnonAuthService.ts
 import Service from '../Service';
 import { SigninRequest, SignupRequest, SigninResponse, SignupResponse } from '@/types/auths';
 

--- a/src/services/auths/AuthService.ts
+++ b/src/services/auths/AuthService.ts
@@ -1,5 +1,3 @@
-// src/services/auths/AuthService.ts
-
 import {
   SignupRequest,
   SignupResponse,
@@ -15,27 +13,27 @@ import PolymorphicHttpClient from '../PolymorphicHttpClient';
 export class AuthService {
   private http = PolymorphicHttpClient.getInstance();
 
-  signup(teamId: string, data: SignupRequest) {
-    return this.http.post<SignupResponse>(`/${teamId}/auths/signup`, data);
+  signup(data: SignupRequest) {
+    return this.http.post<SignupResponse>(`/auths/signup`, data);
   }
 
-  signin(teamId: string, data: SigninRequest) {
-    return this.http.post<SigninResponse>(`/${teamId}/auths/signin`, data);
+  signin(data: SigninRequest) {
+    return this.http.post<SigninResponse>(`/auths/signin`, data);
   }
 
-  signout(teamId: string) {
-    return this.http.post<SignoutResponse>(`/${teamId}/auths/signout`);
+  signout() {
+    return this.http.post<SignoutResponse>(`/auths/signout`);
   }
 
-  getUser(teamId: string) {
-    return this.http.get<GetUserResponse>(`/${teamId}/auths/user`);
+  getUser() {
+    return this.http.get<GetUserResponse>(`/auths/user`);
   }
 
-  updateUser(teamId: string, data: UpdateUserRequest) {
+  updateUser(data: UpdateUserRequest) {
     const formData = new FormData();
     if (data.companyName) formData.append('companyName', data.companyName);
     if (data.image) formData.append('image', data.image);
-    return this.http.put<UpdateUserResponse>(`/${teamId}/auths/user`, formData);
+    return this.http.put<UpdateUserResponse>(`/auths/user`, formData);
   }
 }
 

--- a/src/services/gatherings/AnonGatheringService.ts
+++ b/src/services/gatherings/AnonGatheringService.ts
@@ -1,5 +1,3 @@
-// src/services/gatherings/AnonGatheringService.ts
-
 import Service from '../Service';
 import { IGathering, IParticipant } from '@/types/gatherings';
 

--- a/src/services/gatherings/GatheringService.ts
+++ b/src/services/gatherings/GatheringService.ts
@@ -1,5 +1,3 @@
-// src/services/gatherings/GatheringService.ts
-
 import PolymorphicHttpClient from '../PolymorphicHttpClient';
 import {
   GetGatheringsParams,
@@ -26,11 +24,11 @@ export class GatheringService {
     );
   }
 
-  getGatherings(teamId: string, params?: GetGatheringsParams) {
-    return this.http.get<GetGatheringsResponse>(`/${teamId}/gatherings${this.toQuery(params)}`);
+  getGatherings(params?: GetGatheringsParams) {
+    return this.http.get<GetGatheringsResponse>(`/gatherings${this.toQuery(params)}`);
   }
 
-  createGathering(teamId: string, data: CreateGatheringRequest) {
+  createGathering(data: CreateGatheringRequest) {
     const formData = new FormData();
     formData.append('location', data.location);
     formData.append('type', data.type);
@@ -39,35 +37,33 @@ export class GatheringService {
     formData.append('capacity', String(data.capacity));
     if (data.image) formData.append('image', data.image);
     if (data.registrationEnd) formData.append('registrationEnd', data.registrationEnd);
-    return this.http.post<CreateGatheringResponse>(`/${teamId}/gatherings`, formData);
+    return this.http.post<CreateGatheringResponse>(`/gatherings`, formData);
   }
 
-  getJoinedGatherings(teamId: string, params?: GetJoinedGatheringsParams) {
-    return this.http.get<GetJoinedGatheringsResponse>(
-      `/${teamId}/gatherings/joined${this.toQuery(params)}`,
-    );
+  getJoinedGatherings(params?: GetJoinedGatheringsParams) {
+    return this.http.get<GetJoinedGatheringsResponse>(`/gatherings/joined${this.toQuery(params)}`);
   }
 
-  getGatheringDetail(teamId: string, id: number) {
-    return this.http.get<GetGatheringDetailResponse>(`/${teamId}/gatherings/${id}`);
+  getGatheringDetail(id: number) {
+    return this.http.get<GetGatheringDetailResponse>(`/gatherings/${id}`);
   }
 
-  getParticipants(teamId: string, id: number, params?: GetParticipantsParams) {
+  getParticipants(id: number, params?: GetParticipantsParams) {
     return this.http.get<GetParticipantsResponse>(
-      `/${teamId}/gatherings/${id}/participants${this.toQuery(params)}`,
+      `/gatherings/${id}/participants${this.toQuery(params)}`,
     );
   }
 
-  cancelGathering(teamId: string, id: number) {
-    return this.http.put<CancelGatheringResponse>(`/${teamId}/gatherings/${id}/cancel`);
+  cancelGathering(id: number) {
+    return this.http.put<CancelGatheringResponse>(`/gatherings/${id}/cancel`);
   }
 
-  joinGathering(teamId: string, id: number) {
-    return this.http.post<JoinGatheringResponse>(`/${teamId}/gatherings/${id}/join`);
+  joinGathering(id: number) {
+    return this.http.post<JoinGatheringResponse>(`/gatherings/${id}/join`);
   }
 
-  leaveGathering(teamId: string, id: number) {
-    return this.http.delete<LeaveGatheringResponse>(`/${teamId}/gatherings/${id}/leave`);
+  leaveGathering(id: number) {
+    return this.http.delete<LeaveGatheringResponse>(`/gatherings/${id}/leave`);
   }
 }
 

--- a/src/services/reviews/AnonReviewService.ts
+++ b/src/services/reviews/AnonReviewService.ts
@@ -1,5 +1,3 @@
-// src/services/reviews/AnonReviewService.ts
-
 import Service from '../Service';
 import { GetReviewsResponse, GetReviewScoresResponse } from '@/types/reviews';
 

--- a/src/services/reviews/ReviewService.ts
+++ b/src/services/reviews/ReviewService.ts
@@ -1,5 +1,3 @@
-// src/services/reviews/ReviewService.ts
-
 import PolymorphicHttpClient from '../PolymorphicHttpClient';
 import {
   CreateReviewRequest,
@@ -20,18 +18,16 @@ export class ReviewService {
     );
   }
 
-  createReview(teamId: string, data: CreateReviewRequest) {
-    return this.http.post<CreateReviewResponse>(`/${teamId}/reviews`, data);
+  createReview(data: CreateReviewRequest) {
+    return this.http.post<CreateReviewResponse>(`/reviews`, data);
   }
 
-  getReviews(teamId: string, params?: GetReviewsParams) {
-    return this.http.get<GetReviewsResponse>(`/${teamId}/reviews${this.toQuery(params)}`);
+  getReviews(params?: GetReviewsParams) {
+    return this.http.get<GetReviewsResponse>(`/reviews${this.toQuery(params)}`);
   }
 
-  getReviewScores(teamId: string, params?: GetReviewScoresParams) {
-    return this.http.get<GetReviewScoresResponse>(
-      `/${teamId}/reviews/scores${this.toQuery(params)}`,
-    );
+  getReviewScores(params?: GetReviewScoresParams) {
+    return this.http.get<GetReviewScoresResponse>(`/reviews/scores${this.toQuery(params)}`);
   }
 }
 

--- a/src/services/utlis.ts
+++ b/src/services/utlis.ts
@@ -1,5 +1,3 @@
-// src/services/utils.ts
-
 export function buildQuery(params?: Record<string, string | number | boolean>): string {
   if (!params) return '';
   const entries: [string, string][] = Object.entries(params)


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #111 

## 📝 작업 목록

- [x] ENV 파일 생성
- [x] http 요청할 때 BASEURL, TEAM_ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 환경 변수 기반의 기본 API 주소 지원.
  * 요청 경로에 팀 식별자 자동 포함.

* 리팩터링
  * 인증, 모임, 리뷰 API 경로를 /auths, /gatherings, /reviews로 표준화.
  * teamId 인자 제거로 호출 흐름 간소화.
  * 공통 HTTP 클라이언트 싱글턴 적용으로 통신 일관성 개선.

* 기타
  * 불필요한 헤더/주석 정리로 코드 가독성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->