### PR TITLE
✨ [FEAT] #165 MyGorupCard, ReviewCard의 Skeleton Ui 구현

### DIFF
--- a/src/components/feature/my/MyGroupCardList.tsx
+++ b/src/components/feature/my/MyGroupCardList.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
+import MyGroupCardSkeleton from '@/components/ui/Skeleton/MyGroupCardSkeleton';
 import MyGroupCard from './MyGroupCard';
 
 import { TabVariant } from '@/app/mypage/page';
@@ -67,9 +68,9 @@ export default function MyGroupCardList({
 
   if (isLoading) {
     return (
-      <div className="mx-auto flex w-full flex-col items-center gap-6 md:grid md:grid-cols-2">
+      <div className="mx-auto mt-6 flex w-full flex-col items-center gap-6">
         {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="h-[180px] w-full animate-pulse rounded-lg bg-gray-100" />
+          <MyGroupCardSkeleton key={i} />
         ))}
       </div>
     );

--- a/src/components/feature/review/ReviewCardList.tsx
+++ b/src/components/feature/review/ReviewCardList.tsx
@@ -7,6 +7,7 @@ import { useInfiniteQuery, type InfiniteData } from '@tanstack/react-query';
 import { useMounted } from '@/hooks/useMounted';
 
 import ReviewCard from './ReviewCard';
+import ReviewCardSkeleton from '@/components/ui/Skeleton/ReviewCardSkeleton';
 
 import { cn } from '@/utils/cn';
 import anonReviewService from '@/services/reviews/anonReviewService';
@@ -21,6 +22,11 @@ interface ReviewCardListProps {
 type Page = { data: IReviewWithRelations[]; nextPage?: number };
 
 export default function ReviewCardList({ variants, userId, emptyMsg }: ReviewCardListProps) {
+  const containerClassname = cn(
+    'mx-auto flex w-full flex-col items-center gap-4 rounded-xl bg-white p-6 sm:rounded-2xl md:gap-6',
+    variants === 'my' ? 'mt-4 sm:mt-8 md:mt-9' : 'mt-6',
+    variants === 'my' ? 'md:px-8' : 'md:p-8',
+  );
   const mounted = useMounted();
 
   const { ref, inView } = useInView({ threshold: 0, rootMargin: '100px 0px' });
@@ -52,9 +58,11 @@ export default function ReviewCardList({ variants, userId, emptyMsg }: ReviewCar
 
   if (isLoading) {
     return (
-      <div className="mx-auto flex w-full flex-col items-center gap-6 md:grid md:grid-cols-2">
+      <div className={containerClassname}>
         {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="h-[180px] w-full animate-pulse rounded-lg bg-gray-100" />
+          <div key={i} className="w-full">
+            <ReviewCardSkeleton variant={variants} />
+          </div>
         ))}
       </div>
     );
@@ -84,12 +92,7 @@ export default function ReviewCardList({ variants, userId, emptyMsg }: ReviewCar
 
   return (
     <div>
-      <div
-        className={cn(
-          'mx-auto flex w-full flex-col items-center gap-4 rounded-xl bg-white p-6 sm:rounded-2xl md:gap-6',
-          variants === 'my' ? 'mt-4 sm:mt-8 md:mt-9' : 'mt-6',
-          variants === 'my' ? 'md:px-8' : 'md:p-8',
-        )}>
+      <div className={containerClassname}>
         {list.map(review => (
           <div key={review.id} className="w-full">
             <ReviewCard variant={variants} item={review} />

--- a/src/components/ui/Skeleton/MyGroupCardSkeleton.tsx
+++ b/src/components/ui/Skeleton/MyGroupCardSkeleton.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+export default function MyGroupCardSkeleton() {
+  return (
+    <article
+      className="relative flex h-[390px] w-full animate-pulse cursor-default flex-col gap-4 rounded-lg bg-white shadow-md sm:h-[236px] sm:flex-row sm:p-6 md:gap-6"
+      aria-hidden>
+      <div className="absolute top-5 right-5 h-12 w-12 rounded-full bg-gray-100" />
+
+      <div className="relative h-[156px] w-full overflow-hidden rounded-t-lg bg-gray-100 sm:h-[188px] sm:w-[188px] sm:rounded-xl" />
+
+      <div className="flex h-full min-w-0 flex-1 flex-col justify-between px-4 pb-5 sm:p-0">
+        <div>
+          <div className="mb-4 flex items-center gap-2">
+            <div className="h-8 w-20 rounded bg-gray-100" />
+            <div className="h-8 w-24 rounded border border-gray-200" />
+          </div>
+
+          <div className="mt-4 h-6 w-3/5 rounded bg-gray-100 sm:mt-2" />
+        </div>
+
+        <div className="flex w-full flex-col items-end justify-between sm:flex-row sm:items-center">
+          <div className="tag flex w-full flex-col gap-[6px] sm:gap-[10px]">
+            <div className="flex h-4 items-center gap-2">
+              <div className="h-4 w-4 rounded-full bg-gray-100" />
+              <div className="h-4 w-16 rounded bg-gray-100" />
+            </div>
+
+            <section className="mt-2 flex flex-nowrap items-center gap-2">
+              <div className="h-6 w-16 rounded-full border border-gray-200" />
+              <div className="h-6 w-24 rounded-full border border-gray-200" />
+              <div className="h-6 w-20 rounded-full bg-gray-100" />
+            </section>
+          </div>
+
+          <div className="mt-4 sm:mt-0">
+            <div className="h-[44px] w-[132px] rounded-md bg-gray-100 sm:h-[48px] sm:w-[120px] md:h-[48px] md:w-[156px]" />
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/ui/Skeleton/ReviewCardSkeleton.tsx
+++ b/src/components/ui/Skeleton/ReviewCardSkeleton.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+export default function ReviewCardSkeleton({ variant = 'all' }: { variant?: 'my' | 'all' }) {
+  const mdCols = variant === 'all' ? 'md:grid-cols-[300px_1fr]' : 'md:grid-cols-[200px_1fr]';
+
+  return (
+    <article className="w-full animate-pulse cursor-default rounded-xl border-0" aria-hidden>
+      <div
+        className={`grid grid-cols-[80px_1fr] items-start gap-3 overflow-x-hidden sm:grid-cols-[200px_1fr] md:items-stretch md:gap-6 ${mdCols}`}>
+        <header className="col-span-2 flex items-center gap-3 sm:col-start-2 sm:row-start-1 md:col-start-2 md:row-start-1">
+          <div className="h-10 w-10 shrink-0 rounded-full bg-gray-100" />
+
+          <div className="flex min-w-0 flex-col">
+            <div className="h-4 w-40 max-w-[160px] rounded bg-gray-100 sm:max-w-[220px]" />
+            <div className="mt-0.5 flex items-center gap-2">
+              <div className="flex items-center gap-1">
+                <div className="h-3 w-3 rounded bg-gray-100" />
+                <div className="h-3 w-3 rounded bg-gray-100" />
+                <div className="h-3 w-3 rounded bg-gray-100" />
+                <div className="h-3 w-3 rounded bg-gray-100" />
+                <div className="h-3 w-3 rounded bg-gray-100" />
+              </div>
+              <div className="h-3 w-16 rounded bg-gray-100" />
+            </div>
+          </div>
+        </header>
+
+        <div className="typo-sm col-span-2 row-start-2 mt-1 text-gray-500 sm:hidden">
+          <div className="inline-flex items-center gap-2 align-middle">
+            <div className="h-3 w-px bg-gray-200" />
+            <div className="h-3 w-24 rounded bg-gray-100" />
+          </div>
+        </div>
+
+        <figure className="relative col-start-1 row-start-3 h-[80px] overflow-hidden rounded-lg bg-gray-100 sm:row-span-2 sm:row-start-1 sm:h-[200px] md:row-span-2 md:row-start-1 md:h-[200px]" />
+
+        <section className="col-start-2 row-start-3 mt-2 flex min-w-0 flex-col justify-center sm:row-start-2 sm:mt-0 md:row-span-1 md:row-start-2">
+          <div className="typo-sm hidden text-gray-500 sm:flex">
+            <div className="flex items-center gap-2">
+              <div className="h-3 w-px bg-gray-200" />
+              <div className="h-3 w-28 rounded bg-gray-100" />
+            </div>
+          </div>
+
+          <div className="mt-2 space-y-2 sm:mt-2">
+            <div className="h-4 w-11/12 rounded bg-gray-100" />
+            <div className="h-4 w-10/12 rounded bg-gray-100" />
+            <div className="h-4 w-7/12 rounded bg-gray-100" />
+          </div>
+        </section>
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #165 
- 예: `Closes #10`, `Relates to #8`

## 📝 작업 목록

- [x] MyGroupCard의 Skeleton 구현
- [x] ReviewCard의 Skeleton 구현



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 로딩 상태 시 시각적 일관성을 위한 전용 스켈레톤 로딩 컴포넌트 추가

* **Refactor**
  * 인라인 스켈레톤 플레이스홀더를 재사용 가능한 컴포넌트로 교체
  * 로딩 컨테이너 스타일링 및 레이아웃 관리 개선
  * 카드 리스트 컴포넌트의 레이아웃 스타일링 통합

<!-- end of auto-generated comment: release notes by coderabbit.ai -->