### PR TITLE
⚡️  [FEAT] #180 GroupCard ui ux 개선

### DIFF
--- a/src/components/feature/gathering/CreateGatheringButton.tsx
+++ b/src/components/feature/gathering/CreateGatheringButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { IconButton } from '@/components/ui/IconButton';
@@ -9,10 +9,15 @@ import { ConfirmModal } from '@/components/ui/Modal';
 
 export default function CreateGatheringButton() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isScrolled, setIsScrolled] = useState(false);
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const { isAuthenticated } = useAuthStore();
   const router = useRouter();
-
+  useEffect(() => {
+    const onScroll = () => setIsScrolled(window.scrollY > 120);
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
   const handleClick = () => {
     if (isAuthenticated) {
       setIsCreateModalOpen(true);
@@ -25,7 +30,9 @@ export default function CreateGatheringButton() {
     <>
       <IconButton
         label="모임 만들기"
-        className="fixed right-8 bottom-16 shadow-lg md:right-24 lg:right-32"
+        className={`fixed right-8 bottom-16 shadow-lg transition-opacity duration-300 md:right-24 lg:right-32 ${
+          isScrolled ? 'opacity-55 hover:opacity-100' : 'opacity-100'
+        }`}
         onClick={handleClick}
       />
       <CreateGroupModal open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen} />

--- a/src/components/feature/group/GroupCard.tsx
+++ b/src/components/feature/group/GroupCard.tsx
@@ -89,7 +89,7 @@ export default function GroupCard({ data }: GroupCardProps) {
         className="contents"
         role="link"
         aria-label={`${name} 상세 페이지로 이동`}>
-        <article className="relative flex h-[346px] w-full max-w-[460px] flex-col overflow-hidden rounded-xl bg-white shadow-md transition-all sm:h-[219px] sm:max-w-[1280px] sm:flex-row sm:rounded-2xl sm:p-6 md:max-w-[640px]">
+        <article className="relative flex h-[346px] w-full max-w-[650px] flex-col overflow-hidden rounded-xl bg-white transition-transform duration-300 hover:scale-105 hover:shadow-md sm:h-[219px] sm:max-w-[1280px] sm:flex-row sm:rounded-2xl sm:p-6 md:max-w-[640px]">
           <div className="relative h-[160px] w-full sm:h-[170px] sm:w-[170px] md:h-auto">
             {!image ? (
               <div className="flex h-full w-full items-center justify-center bg-gray-100 text-gray-400 sm:rounded-xl"></div>

--- a/src/components/feature/group/GroupCardList.tsx
+++ b/src/components/feature/group/GroupCardList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import GroupCard from './GroupCard';
+import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
@@ -68,9 +69,17 @@ export default function GroupCardList({ filters }: GroupCardListProps) {
           현재 등록된 모임이 없습니다.
         </span>
       ) : (
-        <div className="mx-auto flex flex-col items-center gap-6 md:grid md:grid-cols-2">
+        <div className="mx-auto flex flex-col gap-6 md:grid md:grid-cols-2">
           {gatherings.map(item => (
-            <GroupCard key={item.id} data={item} />
+            <motion.div
+              key={item.id}
+              className="h-full w-full"
+              initial={{ opacity: 0 }}
+              whileInView={{ opacity: 1 }}
+              viewport={{ once: true, amount: 0.15 }}
+              transition={{ type: 'tween', ease: 'easeOut', duration: 0.4 }}>
+              <GroupCard data={item} />
+            </motion.div>
           ))}
           <div ref={ref} className="text-gray-500">
             {isFetchingNextPage ? '불러오는 중...' : hasNextPage}

--- a/src/components/feature/group/GroupTab.tsx
+++ b/src/components/feature/group/GroupTab.tsx
@@ -12,7 +12,7 @@ export default function GroupTab({ activeMain, handleMainChange }: GroupTabProps
   ] as const;
 
   return (
-    <div className="sm:mt-8">
+    <div className="mt-4 sm:mt-8">
       <Tab<'성장' | '네트워킹'> items={mainTabs} value={activeMain} onChange={handleMainChange} />
     </div>
   );


### PR DESCRIPTION
## 🔗 관련 이슈

- 이 PR이 해결하는 이슈 번호를 명시해주세요.
- 예: `Closes #10`, `Relates to #8`
Closes #180 
## 📝 작업 목록

- [ ] 스크롤시 fade in fade out 애니매이션 추가
- [ ] 모임 만들기 버튼 스크롤시 투명도


## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요. (스크린샷, 리뷰 요구사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Gather 버튼에 스크롤 반응 동작 추가: 스크롤 위치에 따라 버튼 투명도 자동 조절
  * 그룹 카드 목록에 스크롤 기반 페이드-인 애니메이션 추가
  * 그룹 카드 호버 시 스케일 및 그림자 효과 강화

* **Style**
  * 그룹 카드 크기 확대 (가로 460px → 650px)
  * 반응형 레이아웃 여백 미세 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->