### PR TITLE
♻️ [REFACTOR] #189 Custom Hook 분리 및 상태별 참여하기 버튼 분기 수정

### DIFF
--- a/src/components/feature/gathering/detail/GroupDetailCard.tsx
+++ b/src/components/feature/gathering/detail/GroupDetailCard.tsx
@@ -30,6 +30,7 @@ interface GroupDetailCardProps {
   isReviewed?: boolean;
   isRegistrationClosed?: boolean;
   isOpenConfirmed?: boolean;
+  isCanceled?: boolean;
   onJoin?: () => void;
   onLeave?: () => void;
   onCancel?: () => void;
@@ -38,6 +39,7 @@ interface GroupDetailCardProps {
   isJoining?: boolean;
   isLeaving?: boolean;
   isCanceling?: boolean;
+  isFull?: boolean;
 }
 
 export default function GroupDetailCard({
@@ -48,6 +50,8 @@ export default function GroupDetailCard({
   isReviewed = false,
   isRegistrationClosed = false,
   isOpenConfirmed = false,
+  isFull = false,
+  isCanceled = false,
   onJoin,
   onLeave,
   onCancel,
@@ -59,82 +63,139 @@ export default function GroupDetailCard({
 }: GroupDetailCardProps) {
   const { name, deadlineText, dateText, timeText, location } = data;
   const { isAuthenticated } = useAuthStore();
-  const [isSaved, setIsSaved] = useState(false);
   const topic = LocationToTag(location) as 'growth' | 'learn' | 'challenge' | 'connect' | 'default';
   const category = TAG_OPTIONS.find(option => option.value === topic)?.label ?? '';
 
-  const getButtonState = () => {
-    if (!isAuthenticated) return 'JOIN';
+  // 마감 여부 계산
+  const isClosed = isRegistrationClosed || isFull || isCompleted || isCanceled;
 
-    // 모집 마감됐는데 개설 미확정인 경우
-    if (isRegistrationClosed && !isOpenConfirmed) {
-      return 'REGISTRATION_CLOSED';
-    }
-
-    // 모임 완료된 경우
-    if (isCompleted) {
-      if (!joined) {
-        return 'REGISTRATION_CLOSED';
-      }
-      return isReviewed ? 'REVIEWED' : 'WRITE_REVIEW';
-    }
-
-    // 모집 마감됐지만 모임은 아직 진행 전
-    if (isRegistrationClosed) {
-      return 'REGISTRATION_CLOSED';
-    }
-
-    // 모집 진행 중
-    return joined ? 'LEAVE' : 'JOIN';
-  };
-
-  const buttonState = getButtonState();
-
+  // 버튼 상태 계산
   const getButtonProps = () => {
-    switch (buttonState) {
-      case 'JOIN':
+    // 삭제된 모임 처리
+    if (isCanceled) {
+      return {
+        text: '삭제된 모임',
+        onClick: undefined,
+        disabled: true,
+        variant: 'primary' as const,
+      };
+    }
+
+    // 비로그인 사용자 - 일부 로직
+    if (!isAuthenticated) {
+      // 1. 모집 마감 + 개설 미확정
+      if (isRegistrationClosed && !isOpenConfirmed) {
         return {
-          text: '참여하기',
-          onClick: onJoin,
-          disabled: isJoining,
+          text: '개설 취소',
+          onClick: undefined,
+          disabled: true,
           variant: 'primary' as const,
         };
-      case 'LEAVE':
-        return {
-          text: '참여 취소하기',
-          onClick: onLeave,
-          disabled: isLeaving,
-          variant: 'primary' as const,
-        };
-      case 'REGISTRATION_CLOSED':
+      }
+
+      // 2. 모집 마감
+      if (isRegistrationClosed || isCompleted) {
         return {
           text: '참여 기간 만료',
           onClick: undefined,
           disabled: true,
           variant: 'primary' as const,
         };
-      case 'WRITE_REVIEW':
+      }
+
+      // 3. 정원 마감
+      if (isFull) {
         return {
-          text: '리뷰 작성하기',
-          onClick: onWriteReview,
-          disabled: false,
+          text: '정원 마감',
+          onClick: undefined,
+          disabled: true,
           variant: 'primary' as const,
         };
-      case 'REVIEWED':
+      }
+
+      // 4. 참여하기 (클릭 시 로그인 유도)
+      return {
+        text: '참여하기',
+        onClick: onJoin,
+        disabled: false,
+        variant: 'primary' as const,
+      };
+    }
+
+    // 로그인 사용자 - 전체 로직
+    // 1. 모집 마감 + 개설 미확정
+    if (isRegistrationClosed && !isOpenConfirmed) {
+      return {
+        text: '개설 취소',
+        onClick: undefined,
+        disabled: true,
+        variant: 'primary' as const,
+      };
+    }
+
+    // 2. 모임 완료
+    if (isCompleted) {
+      if (!joined) {
+        return {
+          text: '참여 기간 만료',
+          onClick: undefined,
+          disabled: true,
+          variant: 'primary' as const,
+        };
+      }
+      if (isReviewed) {
         return {
           text: '참여 완료',
           onClick: undefined,
           disabled: true,
           variant: 'primary' as const,
         };
-      default:
-        return {
-          text: '참여하기',
-          onClick: onJoin,
-          disabled: false,
-          variant: 'primary' as const,
-        };
+      }
+      return {
+        text: '리뷰 작성하기',
+        onClick: onWriteReview,
+        disabled: false,
+        variant: 'primary' as const,
+      };
     }
+
+    // 3. 모집 마감
+    if (isRegistrationClosed) {
+      return {
+        text: '참여 기간 만료',
+        onClick: undefined,
+        disabled: true,
+        variant: 'primary' as const,
+      };
+    }
+
+    // 4. 정원 마감 (참여 안 한 경우)
+    if (isFull && !joined) {
+      return {
+        text: '정원 마감',
+        onClick: undefined,
+        disabled: true,
+        variant: 'primary' as const,
+      };
+    }
+
+    // 5. 참여 취소하기
+    if (joined) {
+      return {
+        text: '참여 취소하기',
+        onClick: onLeave,
+        disabled: isLeaving,
+        variant: 'secondary' as const,
+      };
+    }
+
+    // 6. 참여하기
+    return {
+      text: '참여하기',
+      onClick: onJoin,
+      disabled: isJoining,
+      variant: 'primary' as const,
+    };
   };
 
   const { text, onClick, disabled, variant } = getButtonProps();
@@ -195,8 +256,17 @@ export default function GroupDetailCard({
 
       {/* 하단: 버튼 영역 */}
       <div className="flex w-full items-center justify-between gap-4 sm:gap-2 md:gap-4">
-        {/* 왼쪽: 찜 버튼 */}
-        <FavoriteButton itemId={data.id} size="responsive" />
+        {/* 왼쪽: 찜 버튼 또는 마감 아이콘 */}
+        {isClosed ? (
+          <div
+            role="img"
+            aria-label="모집 마감됨"
+            className="flex h-10 w-10 cursor-not-allowed items-center justify-center sm:h-12 sm:w-12 md:h-15 md:w-15">
+            <Icon name="save" className="h-full w-full" />
+          </div>
+        ) : (
+          <FavoriteButton itemId={data.id} size="responsive" />
+        )}
 
         {/* 오른쪽: 버튼 그룹 */}
         <div className="flex flex-1 items-center gap-2 sm:gap-3">
@@ -229,10 +299,9 @@ export default function GroupDetailCard({
               size="responsive_full"
               className={cn(
                 'typo-xl h-10 rounded-md font-bold transition-all duration-200 sm:h-12 sm:rounded-md md:h-15 md:rounded-xl',
-                buttonState === 'LEAVE' &&
+                variant === 'secondary' &&
                   'border border-purple-600 bg-white text-purple-600 hover:bg-purple-50',
-                (disabled || buttonState === 'REGISTRATION_CLOSED') &&
-                  'pointer-events-none cursor-not-allowed opacity-50',
+                disabled && 'pointer-events-none cursor-not-allowed opacity-50',
               )}>
               {text}
             </Button>

--- a/src/hooks/useGatheringButtonState.ts
+++ b/src/hooks/useGatheringButtonState.ts
@@ -1,0 +1,63 @@
+import { isClosed } from '@/utils/date';
+import type { IGathering, IJoinedGathering, IParticipant } from '@/types/gatherings';
+import type { GetReviewsResponse } from '@/types/reviews';
+
+interface UseGatheringButtonStateParams {
+  gathering: IGathering | null | undefined;
+  participantsData: IParticipant[] | undefined;
+  joinedGatherings: IJoinedGathering[] | undefined;
+  myReviews: GetReviewsResponse | undefined;
+  gatheringId: string | number;
+  userId: number | null;
+  minParticipants?: number;
+}
+
+export function useGatheringButtonState({
+  gathering,
+  participantsData,
+  joinedGatherings,
+  myReviews,
+  gatheringId,
+  userId,
+  minParticipants,
+}: UseGatheringButtonStateParams) {
+  // 참가 여부 확인
+  const joined = joinedGatherings?.some(g => g.id === Number(gatheringId)) ?? false;
+
+  // 참가자 수 계산
+  const currentParticipantCount = participantsData?.length ?? gathering?.participantCount ?? 0;
+  const capacity = gathering?.capacity ?? 20;
+
+  // 정원 초과 여부
+  const isFull = currentParticipantCount >= capacity;
+
+  // 개설 확정 여부 (최소 인원 충족)
+  const minRequired = minParticipants ?? 5;
+  const isOpenConfirmed = currentParticipantCount >= minRequired;
+
+  // 리뷰 작성 여부
+  const isReviewed = (myReviews?.data?.length ?? 0) > 0;
+
+  // 모임 완료 여부 (날짜 지남)
+  const isCompleted = isClosed(gathering?.dateTime);
+
+  // 모집 마감 여부
+  const isRegistrationClosed = isClosed(gathering?.registrationEnd);
+
+  // 삭제 여부
+  const isCanceled = !!gathering?.canceledAt;
+
+  return {
+    joined,
+    userId,
+    currentParticipantCount,
+    capacity,
+    minRequired,
+    isOpenConfirmed,
+    isReviewed,
+    isCompleted,
+    isRegistrationClosed,
+    isFull,
+    isCanceled,
+  };
+}

--- a/src/hooks/useGatheringDetail.ts
+++ b/src/hooks/useGatheringDetail.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { gatheringService } from '@/services/gatherings/gatheringService';
+import { mapGatheringToUI } from '@/utils/mapping';
+
+export function useGatheringDetail(gatheringId: string | number, userId: number | null) {
+  const {
+    data: gathering,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['gatheringDetail', gatheringId],
+    queryFn: async () => {
+      const res = await gatheringService.getGatheringDetail(Number(gatheringId));
+      return res;
+    },
+    enabled: !!gatheringId,
+    staleTime: 1000 * 60 * 3,
+  });
+  const uiData = gathering ? mapGatheringToUI(gathering, userId) : null;
+
+  return {
+    uiData,
+    gathering,
+    isLoading,
+    isError,
+  };
+}

--- a/src/hooks/useGatheringHandler.ts
+++ b/src/hooks/useGatheringHandler.ts
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+import { useToast } from '@/components/ui/Toast';
+import { gatheringService } from '@/services/gatherings/gatheringService';
+import { copyToClipboard } from '@/utils/clipboard';
+
+interface useGatheringHandlersParams {
+  gatheringId: string | number;
+  userId: number | null;
+  isAuthenticated: boolean;
+}
+
+export function useGatheringHandlers({
+  gatheringId,
+  userId,
+  isAuthenticated,
+}: useGatheringHandlersParams) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  const [isJoining, setIsJoining] = useState(false);
+  const [isLeaving, setIsLeaving] = useState(false);
+  const [isCanceling, setIsCanceling] = useState(false);
+
+  // 참여하기
+  const handleJoin = async () => {
+    if (!isAuthenticated) {
+      showToast('로그인 후 이용 가능합니다.', 'error');
+      setTimeout(() => {
+        router.push('/login');
+      }, 1000);
+      return;
+    }
+    setIsJoining(true);
+    try {
+      await gatheringService.joinGathering(Number(gatheringId));
+      showToast('모임에 참여했습니다!', 'success');
+      queryClient.invalidateQueries({ queryKey: ['gatheringParticipants', gatheringId] });
+      queryClient.invalidateQueries({ queryKey: ['joinedGatherings', userId] });
+    } catch {
+      showToast('모임 참여 요청에 실패했습니다.', 'error');
+    } finally {
+      setIsJoining(false);
+    }
+  };
+
+  // 참여 취소하기
+  const handleLeave = async () => {
+    setIsLeaving(true);
+    try {
+      await gatheringService.leaveGathering(Number(gatheringId));
+      showToast('모임 참여를 취소했습니다.', 'info');
+      queryClient.invalidateQueries({ queryKey: ['gatheringParticipants', gatheringId] });
+      queryClient.invalidateQueries({ queryKey: ['joinedGatherings', userId] });
+    } catch {
+      showToast('모임 참여 취소가 실패했습니다.', 'error');
+    } finally {
+      setIsLeaving(false);
+    }
+  };
+
+  // 모임 삭제 (주최자인 경우)
+  const handleCancel = async () => {
+    setIsCanceling(true);
+    try {
+      await gatheringService.cancelGathering(Number(gatheringId));
+      showToast('모임이 삭제되었습니다.', 'success');
+
+      // 삭제 후: 관련 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ['gatherings'] });
+      setTimeout(() => router.replace('/gathering'), 1000);
+    } catch {
+      showToast('모임이 삭제되지 않았습니다.', 'error');
+    } finally {
+      setIsCanceling(false);
+    }
+  };
+
+  // 공유하기
+  const handleShare = async () => {
+    const ok = await copyToClipboard(window.location.href);
+    showToast(
+      ok ? '링크가 복사되었습니다!' : '링크가 복사되지 않았습니다!',
+      ok ? 'success' : 'error',
+    );
+  };
+
+  return {
+    handleJoin,
+    handleLeave,
+    handleCancel,
+    handleShare,
+    isJoining,
+    isLeaving,
+    isCanceling,
+  };
+}

--- a/src/hooks/useGatheringParticipants.ts
+++ b/src/hooks/useGatheringParticipants.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { gatheringService } from '@/services/gatherings/gatheringService';
+import type { IParticipant } from '@/types/gatherings';
+interface ParticipantUI {
+  id: number;
+  image: string;
+}
+
+export function useGatheringParticipants(gatheringId: string | number) {
+  const { data: participantsData, ...rest } = useQuery({
+    queryKey: ['gatheringParticipants', gatheringId],
+    queryFn: () => gatheringService.getParticipants(Number(gatheringId)),
+    enabled: !!gatheringId,
+  });
+
+  // UI용 데이터 변환
+  const participants: ParticipantUI[] = useMemo(
+    () =>
+      participantsData?.map((p: IParticipant) => ({
+        id: p.User.id,
+        image: p.User.image || '/images/avatar-default.png',
+      })) ?? [],
+    [participantsData],
+  );
+
+  const count = participantsData?.length ?? 0;
+
+  return {
+    data: participantsData,
+    participants,
+    count,
+    ...rest,
+  };
+}

--- a/src/hooks/useGatheringRedirect.ts
+++ b/src/hooks/useGatheringRedirect.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useToast } from '@/components/ui/Toast';
+
+export function useGatheringRedirect(isCanceled: boolean, isLoading: boolean) {
+  const router = useRouter();
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    if (isCanceled && !isLoading) {
+      showToast('삭제된 모임입니다.', 'error');
+      setTimeout(() => {
+        router.push('/gathering');
+      }, 1500);
+    }
+  }, [isCanceled, isLoading, router, showToast]);
+}

--- a/src/hooks/useJoinedGatherings.ts
+++ b/src/hooks/useJoinedGatherings.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { gatheringService } from '@/services/gatherings/gatheringService';
+
+export function useJoinedGatherings(userId: number | null, isAuthenticated: boolean) {
+  return useQuery({
+    queryKey: ['joinedGatherings', userId],
+    queryFn: () => gatheringService.getJoinedGatherings(),
+    enabled: !!userId && isAuthenticated,
+    staleTime: 1000 * 60 * 3,
+  });
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #189 

## 📝 작업 목록

- [x] GroupDetailPage Custom Hook 분리 및 로직 구조화
- [x] 로그인 상태별 참여하기 버튼 분기 로직 수정
- [x] 모집/정원 마감 시 버튼 예외 분기 로직 추가

## 🙋‍♀️ 기타 참고사항(선택)
<img width="1920" height="1049" alt="screencapture-localhost-3000-gathering-3331-2025-10-28-17_54_56" src="https://github.com/user-attachments/assets/a6f8dce9-68e9-43e3-96c2-23d1dbb30329" />
<img width="1920" height="1480" alt="screencapture-localhost-3000-gathering-3409-2025-10-28-17_54_14" src="https://github.com/user-attachments/assets/e265542e-4f61-44cd-a1eb-879b2be223da" />
<img width="1920" height="1055" alt="screencapture-localhost-3000-gathering-3476-2025-10-28-20_42_56" src="https://github.com/user-attachments/assets/dfc12b1a-cae4-4587-9cf5-45691fcf4a5f" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 삭제된 모임에 대한 사용자 친화적 처리 및 자동 리다이렉트 추가
  * 데이터 로딩 중 스켈레톤 로딩 컴포넌트 도입으로 개선된 사용자 경험

* **개선 사항**
  * 모임 참여 상태 및 버튼 로직 최적화
  * 정원 마감 및 삭제된 모임 상태 표시 개선
  * 데이터 조회 효율성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->