### PR TITLE
🐛 [FIX] #217 모임 삭제 시 찜하기 자동 해제 로직 추가

### DIFF
--- a/src/hooks/useGatheringHandler.ts
+++ b/src/hooks/useGatheringHandler.ts
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '@/components/ui/Toast';
 import { gatheringService } from '@/services/gatherings/gatheringService';
 import { copyToClipboard } from '@/utils/clipboard';
+import { useFavoriteStore } from '@/stores/useFavoriteStore';
 
 interface useGatheringHandlersParams {
   gatheringId: string | number;
@@ -19,6 +20,7 @@ export function useGatheringHandlers({
   const router = useRouter();
   const queryClient = useQueryClient();
   const { showToast } = useToast();
+  const { removeFavorite } = useFavoriteStore();
 
   const [isJoining, setIsJoining] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
@@ -66,6 +68,10 @@ export function useGatheringHandlers({
     setIsCanceling(true);
     try {
       await gatheringService.cancelGathering(Number(gatheringId));
+
+      // 찜하기 해제 (찜한 상태라면 자동 해제)
+      removeFavorite(Number(gatheringId));
+
       showToast('모임이 삭제되었습니다.', 'success');
 
       // 삭제 후: 관련 캐시 무효화

--- a/src/stores/useFavoriteStore.ts
+++ b/src/stores/useFavoriteStore.ts
@@ -5,6 +5,7 @@ import { useUserStore } from '@/stores/useUserStore';
 interface FavoriteState {
   favorites: Record<string, number[]>;
   toggleFavorite: (id: number) => void;
+  removeFavorite: (id: number) => void;
   isFavorite: (id: number) => boolean;
   getFavoriteCount: () => number;
   getFavorites: () => number[];
@@ -33,6 +34,27 @@ export const useFavoriteStore = create<FavoriteState>()(
             favorites: {
               ...state.favorites,
               [key]: updatedFavorites,
+            },
+          };
+        });
+      },
+
+      // 찜하기 강제 해제
+      removeFavorite: (id: number) => {
+        const key = getCurrentUserKey();
+
+        set(state => {
+          const currentFavorites = state.favorites[key] || [];
+
+          // 이미 찜한 상태가 아니면 아무것도 안 함
+          if (!currentFavorites.includes(id)) {
+            return state;
+          }
+
+          return {
+            favorites: {
+              ...state.favorites,
+              [key]: currentFavorites.filter(favId => favId !== id),
             },
           };
         });


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #217 

## 📝 작업 목록

- [x] useFavoriteStore.ts에 removeFavorite 로직 추가
- [x] useGatheringHandlers.ts 내 removeFavorite 호출

## 🙋‍♀️ 기타 참고사항(선택)

- 스크린샷
<img width="1920" height="953" alt="screencapture-localhost-3000-favorites-2025-10-29-17_12_06" src="https://github.com/user-attachments/assets/1c7f8cf1-318d-4736-b575-e3add0541572" />
<img width="1920" height="1248" alt="screencapture-localhost-3000-gathering-2025-10-29-17_12_17" src="https://github.com/user-attachments/assets/ee2679ab-d407-4a68-9ed8-d452170a0b16" />
<img width="1920" height="953" alt="screencapture-localhost-3000-favorites-2025-10-29-17_12_30" src="https://github.com/user-attachments/assets/580f7425-49f9-437d-b0e4-bcece9088868" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모임 취소 시 즐겨찾기에서 자동으로 제거되도록 개선되었습니다.
  * 즐겨찾기 항목을 직접 제거할 수 있는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->