### PR TITLE
⚡️ [PERF] #255 모든리뷰 페이지 Prefetch 적용

### DIFF
--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -1,174 +1,41 @@
-'use client';
+import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query';
+import ReviewsPage from '@/components/feature/review/ReviewsPage';
+import { ENV } from '@/constants/env';
+import type { GetReviewScoresResponse } from '@/types/reviews';
 
-import { useGroupFilters } from '@/hooks/useGroupFilters';
-import { useReviewScoresQuery } from '@/hooks/useReviewScoreQuery';
-import type { GetReviewScoresParams } from '@/types/reviews';
-import Tab from '@/components/ui/Tab';
-import Category from '@/components/ui/Category';
-import Dropdown from '@/components/ui/Dropdown';
-import { Calendar } from '@/components/ui/Calendar';
-import IconText from '@/components/ui/IconText';
-import { REVIEW_SORT_OPTIONS, TAG_OPTIONS } from '@/constants';
-import ReviewStatsCard from '@/components/feature/review/ReviewStatsCard';
-import AllReviewList from '@/components/feature/review/AllReviewList';
-
-export default function ReviewsPage() {
-  const filter = useGroupFilters('review');
-
-  const statsParams: GetReviewScoresParams = {};
-  const { data, isLoading } = useReviewScoresQuery(statsParams);
-
-  const mainTabs = [
-    { value: '성장', label: '성장' },
-    { value: '네트워킹', label: '네트워킹' },
-  ] as const;
-
-  const aggregatedStats = data?.reduce(
-    (acc, curr) => ({
-      totalReviews:
-        acc.totalReviews +
-        curr.oneStar +
-        curr.twoStars +
-        curr.threeStars +
-        curr.fourStars +
-        curr.fiveStars,
-      sumScores:
-        acc.sumScores +
-        (curr.oneStar * 1 +
-          curr.twoStars * 2 +
-          curr.threeStars * 3 +
-          curr.fourStars * 4 +
-          curr.fiveStars * 5),
-      oneStar: acc.oneStar + curr.oneStar,
-      twoStars: acc.twoStars + curr.twoStars,
-      threeStars: acc.threeStars + curr.threeStars,
-      fourStars: acc.fourStars + curr.fourStars,
-      fiveStars: acc.fiveStars + curr.fiveStars,
-    }),
-    {
-      totalReviews: 0,
-      sumScores: 0,
-      oneStar: 0,
-      twoStars: 0,
-      threeStars: 0,
-      fourStars: 0,
-      fiveStars: 0,
+export default async function Page() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 1000 * 60 * 5,
+      },
     },
-  );
+  });
 
-  const total = aggregatedStats?.totalReviews ?? 0;
-  const average = total > 0 ? aggregatedStats!.sumScores / total : 0;
-  const distribution = aggregatedStats
-    ? [
-        aggregatedStats.fiveStars,
-        aggregatedStats.fourStars,
-        aggregatedStats.threeStars,
-        aggregatedStats.twoStars,
-        aggregatedStats.oneStar,
-      ]
-    : [0, 0, 0, 0, 0];
+  try {
+    await queryClient.prefetchQuery({
+      queryKey: ['reviewScores', {}],
+      queryFn: async (): Promise<GetReviewScoresResponse> => {
+        const res = await fetch(`${ENV.API_BASE_URL}/${ENV.TEAM_ID}/reviews/scores`, {
+          cache: 'no-store',
+        });
+
+        if (!res.ok) {
+          throw new Error(`Failed to fetch review scores: ${res.status}`);
+        }
+
+        return res.json();
+      },
+    });
+  } catch (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[Prefetch Error]', error);
+    }
+  }
 
   return (
-    <div className="flex flex-col">
-      <div className="sm:mt-8">
-        <Tab items={mainTabs} value={filter.activeMain} onChange={filter.handleMainChange} />
-      </div>
-
-      <div className="mt-4 mb-4 flex flex-col gap-1.5 sm:mt-8 sm:flex-row sm:items-center">
-        {filter.activeMain === '성장' && (
-          <div>
-            <Category
-              mainCategory="성장"
-              activeId={filter.activeSubId}
-              activeType={filter.activeSubType}
-              onChange={filter.handleCategoryChange}
-            />
-          </div>
-        )}
-
-        <div className="flex items-center font-medium text-gray-500 sm:ml-auto sm:h-[40px]">
-          <div ref={filter.tagRef} className="relative">
-            <IconText
-              icon="arrow"
-              iconPosition="trailing"
-              className="cursor-pointer px-2 hover:text-gray-800"
-              onClick={() => filter.setIsTagOpen(prev => !prev)}>
-              {filter.selectedTag}
-            </IconText>
-            {filter.isTagOpen && (
-              <div className="absolute z-10 mt-2 sm:top-full sm:right-0">
-                <Dropdown
-                  items={TAG_OPTIONS}
-                  onChange={filter.handleTagSelect}
-                  onOpenChange={filter.setIsTagOpen}
-                  size="small"
-                />
-              </div>
-            )}
-          </div>
-
-          <div ref={filter.calendarRef} className="relative">
-            <IconText
-              icon="arrow"
-              iconPosition="trailing"
-              className="cursor-pointer px-2 hover:text-gray-800"
-              onClick={() => filter.setIsCalendarOpen(prev => !prev)}>
-              {filter.selectedDate
-                ? filter.selectedDate.toLocaleDateString('ko-KR', {
-                    month: '2-digit',
-                    day: '2-digit',
-                  })
-                : '날짜 전체'}
-            </IconText>
-
-            {filter.isCalendarOpen && (
-              <div className="absolute z-10 mt-2 sm:top-full sm:right-0">
-                <Calendar
-                  cancelLabel="초기화"
-                  value={filter.selectedDate}
-                  onCancel={() => {
-                    filter.setSelectedDate(undefined);
-                    filter.setIsCalendarOpen(false);
-                  }}
-                  onConfirm={filter.handleDateConfirm}
-                />
-              </div>
-            )}
-          </div>
-
-          <div ref={filter.filterRef} className="relative">
-            <IconText
-              icon="filter"
-              iconColor="var(--color-gray-800)"
-              className="cursor-pointer px-2 hover:text-gray-800"
-              onClick={() => filter.setIsFilterOpen(prev => !prev)}>
-              {filter.selectedReviewFilter}
-            </IconText>
-
-            {filter.isFilterOpen && (
-              <div className="absolute top-full right-0 z-10 mt-2">
-                <Dropdown
-                  items={REVIEW_SORT_OPTIONS}
-                  onChange={filter.handleReviewFilterSelect}
-                  onOpenChange={filter.setIsFilterOpen}
-                  size="medium"
-                />
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {isLoading ? (
-        <div className="flex h-40 items-center justify-center text-gray-500" aria-busy="true">
-          로딩 중...
-        </div>
-      ) : (
-        <>
-          <ReviewStatsCard average={average} total={total} distribution={distribution} />
-          <AllReviewList params={filter.params} />
-        </>
-      )}
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ReviewsPage />
+    </HydrationBoundary>
   );
 }

--- a/src/components/feature/review/ReviewsPage.tsx
+++ b/src/components/feature/review/ReviewsPage.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useGroupFilters } from '@/hooks/useGroupFilters';
+import { useReviewScoresQuery } from '@/hooks/useReviewScoreQuery';
+import Tab from '@/components/ui/Tab';
+import Category from '@/components/ui/Category';
+import Dropdown from '@/components/ui/Dropdown';
+import { Calendar } from '@/components/ui/Calendar';
+import IconText from '@/components/ui/IconText';
+import { REVIEW_SORT_OPTIONS, TAG_OPTIONS } from '@/constants';
+import ReviewStatsCard from './ReviewStatsCard';
+import AllReviewList from './AllReviewList';
+
+export default function ReviewsPage() {
+  const filter = useGroupFilters('review');
+  const { data, isLoading } = useReviewScoresQuery({});
+
+  const mainTabs = [
+    { value: '성장', label: '성장' },
+    { value: '네트워킹', label: '네트워킹' },
+  ] as const;
+
+  const aggregatedStats = data?.reduce(
+    (acc, curr) => ({
+      totalReviews:
+        acc.totalReviews +
+        curr.oneStar +
+        curr.twoStars +
+        curr.threeStars +
+        curr.fourStars +
+        curr.fiveStars,
+      sumScores:
+        acc.sumScores +
+        (curr.oneStar * 1 +
+          curr.twoStars * 2 +
+          curr.threeStars * 3 +
+          curr.fourStars * 4 +
+          curr.fiveStars * 5),
+      oneStar: acc.oneStar + curr.oneStar,
+      twoStars: acc.twoStars + curr.twoStars,
+      threeStars: acc.threeStars + curr.threeStars,
+      fourStars: acc.fourStars + curr.fourStars,
+      fiveStars: acc.fiveStars + curr.fiveStars,
+    }),
+    {
+      totalReviews: 0,
+      sumScores: 0,
+      oneStar: 0,
+      twoStars: 0,
+      threeStars: 0,
+      fourStars: 0,
+      fiveStars: 0,
+    },
+  );
+
+  const total = aggregatedStats?.totalReviews ?? 0;
+  const average = total > 0 ? aggregatedStats!.sumScores / total : 0;
+  const distribution = aggregatedStats
+    ? [
+        aggregatedStats.fiveStars,
+        aggregatedStats.fourStars,
+        aggregatedStats.threeStars,
+        aggregatedStats.twoStars,
+        aggregatedStats.oneStar,
+      ]
+    : [0, 0, 0, 0, 0];
+
+  return (
+    <div className="flex flex-col">
+      <div className="sm:mt-8">
+        <Tab items={mainTabs} value={filter.activeMain} onChange={filter.handleMainChange} />
+      </div>
+
+      <div className="mt-4 mb-4 flex flex-col gap-1.5 sm:mt-8 sm:flex-row sm:items-center">
+        {filter.activeMain === '성장' && (
+          <div>
+            <Category
+              mainCategory="성장"
+              activeId={filter.activeSubId}
+              activeType={filter.activeSubType}
+              onChange={filter.handleCategoryChange}
+            />
+          </div>
+        )}
+
+        <div className="flex items-center font-medium text-gray-500 sm:ml-auto sm:h-[40px]">
+          <div ref={filter.tagRef} className="relative">
+            <IconText
+              icon="arrow"
+              iconPosition="trailing"
+              className="cursor-pointer px-2 hover:text-gray-800"
+              onClick={() => filter.setIsTagOpen(prev => !prev)}>
+              {filter.selectedTag}
+            </IconText>
+            {filter.isTagOpen && (
+              <div className="absolute z-10 mt-2 sm:top-full sm:right-0">
+                <Dropdown
+                  items={TAG_OPTIONS}
+                  onChange={filter.handleTagSelect}
+                  onOpenChange={filter.setIsTagOpen}
+                  size="small"
+                />
+              </div>
+            )}
+          </div>
+
+          <div ref={filter.calendarRef} className="relative">
+            <IconText
+              icon="arrow"
+              iconPosition="trailing"
+              className="cursor-pointer px-2 hover:text-gray-800"
+              onClick={() => filter.setIsCalendarOpen(prev => !prev)}>
+              {filter.selectedDate
+                ? filter.selectedDate.toLocaleDateString('ko-KR', {
+                    month: '2-digit',
+                    day: '2-digit',
+                  })
+                : '날짜 전체'}
+            </IconText>
+
+            {filter.isCalendarOpen && (
+              <div className="absolute z-10 mt-2 sm:top-full sm:right-0">
+                <Calendar
+                  cancelLabel="초기화"
+                  value={filter.selectedDate}
+                  onCancel={() => {
+                    filter.setSelectedDate(undefined);
+                    filter.setIsCalendarOpen(false);
+                  }}
+                  onConfirm={filter.handleDateConfirm}
+                />
+              </div>
+            )}
+          </div>
+
+          <div ref={filter.filterRef} className="relative">
+            <IconText
+              icon="filter"
+              iconColor="var(--color-gray-800)"
+              className="cursor-pointer px-2 hover:text-gray-800"
+              onClick={() => filter.setIsFilterOpen(prev => !prev)}>
+              {filter.selectedReviewFilter}
+            </IconText>
+
+            {filter.isFilterOpen && (
+              <div className="absolute top-full right-0 z-10 mt-2">
+                <Dropdown
+                  items={REVIEW_SORT_OPTIONS}
+                  onChange={filter.handleReviewFilterSelect}
+                  onOpenChange={filter.setIsFilterOpen}
+                  size="medium"
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex h-40 items-center justify-center text-gray-500" aria-busy="true">
+          로딩 중...
+        </div>
+      ) : (
+        <>
+          <ReviewStatsCard average={average} total={total} distribution={distribution} />
+          <AllReviewList params={filter.params} />
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #255 

## 📝 작업 목록

- [x] reviews/page.tsx → Server Component로 전환
- [x] 서버에서 `/reviews/scores` API prefetch 구현
- [x] React Query dehydrate/hydrate 적용 (서버에서 리뷰 통계 데이터 사전 로딩)
- [x] UI 로직을 ReviewsPage.tsx (Client Component)로 분리

## 🙋‍♀️ 기타 참고사항(선택)

- 스크린샷
<img width="1023" height="671" alt="화면 캡처 2025-11-02 045359" src="https://github.com/user-attachments/assets/02c4a202-6149-442e-92ef-0b1c0bf9c074" />
<img width="1030" height="266" alt="화면 캡처 2025-11-02 045440" src="https://github.com/user-attachments/assets/cc955ec5-237c-4981-af5d-6419abd902ac" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 리뷰 페이지에 고급 필터링 및 정렬 옵션 추가 (태그, 날짜, 정렬 기능 포함)
  * 리뷰 통계 카드로 집계된 메트릭 표시 (전체 리뷰 수, 평점 분포 등)

* **Performance**
  * 서버 사이드 데이터 프리페칭으로 리뷰 페이지 로딩 성능 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->