### PR TITLE
🐛 [FIX] #274 list에 refetchOnmount:always 로 변경

### DIFF
--- a/src/app/gathering/page.tsx
+++ b/src/app/gathering/page.tsx
@@ -41,10 +41,8 @@ export default async function GatheringPage() {
 
   await queryClient.prefetchInfiniteQuery({
     queryKey,
-    queryFn: async ({ pageParam = 1 }) => {
-      const data = await getGatheringInfiniteList(pageParam, toGetGatheringsParams(defaultFilters));
-      return data;
-    },
+    queryFn: ({ pageParam = 1 }) =>
+      getGatheringInfiniteList(pageParam, toGetGatheringsParams(defaultFilters)),
     initialPageParam: 1,
   });
 

--- a/src/components/feature/group/GroupCardList.tsx
+++ b/src/components/feature/group/GroupCardList.tsx
@@ -24,8 +24,8 @@ export default function GroupCardList({ filters }: GroupCardListProps) {
       queryFn: async ({ pageParam = 1 }) => {
         return getGatheringInfiniteList(pageParam, toGetGatheringsParams(filters));
       },
-
       initialPageParam: 1,
+      refetchOnMount: 'always',
       getNextPageParam: lastPage => lastPage.nextPage,
     });
 


### PR DESCRIPTION
## 🔗 관련 이슈

- 이 PR이 해결하는 이슈 번호를 명시해주세요.
- 예: `Closes #10`, `Relates to #8`
Closes #274 
## 📝 작업 목록

- [ ] list에 refetchOnmount:always 로 변경


## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요. (스크린샷, 리뷰 요구사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 최적화

* 쿼리 함수 성능을 개선했습니다.
* 그룹 목록을 탐색할 때 항상 최신 데이터가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->