### PR TITLE
🐛 [FIX] #279 Review card 이미지 없을때 ui 개선

### DIFF
--- a/src/components/feature/review/ReviewCard.tsx
+++ b/src/components/feature/review/ReviewCard.tsx
@@ -69,7 +69,16 @@ export default function ReviewCard({ variant, item }: ReviewCardProps) {
 
             {/* 모임 썸네일 이미지 */}
             <figure
-              className={`relative col-start-1 row-start-3 h-[80px] overflow-hidden rounded-lg bg-gray-100 sm:row-span-2 sm:row-start-1 sm:h-[200px] md:row-span-2 md:row-start-1 md:h-[200px]`}>
+              className={`relative col-start-1 row-start-3 h-[80px] overflow-hidden rounded-lg bg-white sm:row-span-2 sm:row-start-1 sm:h-[200px] md:row-span-2 md:row-start-1 md:h-[200px]`}>
+              {!gatheringImage && (
+                <Image
+                  src="/images/header_logo.webp"
+                  alt="not_image"
+                  width={400}
+                  height={260}
+                  className="h-full w-full object-cover"
+                />
+              )}
               {gatheringImage && (
                 <Image
                   src={gatheringImage}


### PR DESCRIPTION
## 🔗 관련 이슈

- 이 PR이 해결하는 이슈 번호를 명시해주세요.
- 예: `Closes #10`, `Relates to #8`
Closes #279 
## 📝 작업 목록

- [ ]  Review card 이미지 없을때 ui 개선
-
## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요. (스크린샷, 리뷰 요구사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX 개선**
  * 모임 썸네일 이미지가 없을 때 기본 플레이스홀더 이미지가 표시되도록 개선했습니다.
  * 모임 카드의 시각적 일관성을 위해 배경 스타일을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->